### PR TITLE
Implementing default confirmation of system changes

### DIFF
--- a/PSSpeedTest/public/Install-SpeedTestServer.ps1
+++ b/PSSpeedTest/public/Install-SpeedTestServer.ps1
@@ -19,9 +19,6 @@
     .PARAMETER PassThru
     Returns the object returned by "Get-Process -Name 'iperf3' -ErrorAction 'SilentlyContinue'".
 
-    .PARAMETER Force
-    Skips any confirmations of installation of the ChocolateyGet PackageProvider and iPerf3 package.
-
     .EXAMPLE
     Install-SpeedTestServer -ComputerName SERVER01 -Port 5201 -Credential domain\user
     Sets up computer SERVER01 as an iPerf3 server listening on port 5201.
@@ -48,9 +45,7 @@ function Install-SpeedTestServer {
         [PSCredential]
         $Credential,
         [Switch]
-        $PassThru,
-        [Switch]
-        $Force
+        $PassThru
     )
 
     $timeout = 30 # Seconds
@@ -61,8 +56,8 @@ function Install-SpeedTestServer {
 
     if (!($ComputerName)) {
         Write-Verbose -Message "Setting up server on local machine on port $Port."
-        Install-ChocolateyGetProvider -Force:$Force
-        Install-iPerf3 -Force:$Force
+        Install-ChocolateyGetProvider
+        Install-iPerf3
         Set-iPerf3Port -Port $Port
         Set-iPerf3Task -Port $Port
 
@@ -93,8 +88,8 @@ function Install-SpeedTestServer {
         if (!($Credential)) {
             Write-Verbose -Message "Setting up server on domain machine $ComputerName on port $Port."
             try {
-                Invoke-Command -ComputerName $ComputerName -ScriptBlock ${Function:Install-ChocolateyGetProvider} -ArgumentList $Force
-                Invoke-Command -ComputerName $ComputerName -ScriptBlock ${Function:Install-iPerf3} -ArgumentList $Force
+                Invoke-Command -ComputerName $ComputerName -ScriptBlock ${Function:Install-ChocolateyGetProvider}
+                Invoke-Command -ComputerName $ComputerName -ScriptBlock ${Function:Install-iPerf3}
                 Invoke-Command -ComputerName $ComputerName -ScriptBlock ${Function:Set-iPerf3Port} -ArgumentList $Port
                 Invoke-Command -ComputerName $ComputerName -ScriptBlock ${Function:Set-iPerf3Task} -ArgumentList $Port
             }
@@ -128,8 +123,8 @@ function Install-SpeedTestServer {
         else {
             Write-Verbose -Message "Setting up server on domain machine $ComputerName on port $Port with credential $Credential."
             try {
-                Invoke-Command -ComputerName $ComputerName -ScriptBlock ${Function:Install-ChocolateyGetProvider} -Credential $Credential -ArgumentList $Force
-                Invoke-Command -ComputerName $ComputerName -ScriptBlock ${Function:Install-iPerf3} -Credential $Credential -ArgumentList $Force
+                Invoke-Command -ComputerName $ComputerName -ScriptBlock ${Function:Install-ChocolateyGetProvider} -Credential $Credential
+                Invoke-Command -ComputerName $ComputerName -ScriptBlock ${Function:Install-iPerf3} -Credential $Credential
                 Invoke-Command -ComputerName $ComputerName -ScriptBlock ${Function:Set-iPerf3Port} -ArgumentList $Port -Credential $Credential
                 Invoke-Command -ComputerName $ComputerName -ScriptBlock ${Function:Set-iPerf3Task} -ArgumentList $Port -Credential $Credential
             }

--- a/PSSpeedTest/public/Install-SpeedTestServer.ps1
+++ b/PSSpeedTest/public/Install-SpeedTestServer.ps1
@@ -33,7 +33,7 @@
 #>
 
 function Install-SpeedTestServer {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess=$True)]
     Param (
         [ValidateNotNullOrEmpty()]
         [String]

--- a/PSSpeedTest/public/Install-SpeedTestServer.ps1
+++ b/PSSpeedTest/public/Install-SpeedTestServer.ps1
@@ -33,7 +33,7 @@
 #>
 
 function Install-SpeedTestServer {
-    [CmdletBinding(SupportsShouldProcess=$True)]
+    [CmdletBinding()]
     Param (
         [ValidateNotNullOrEmpty()]
         [String]

--- a/PSSpeedTest/public/Invoke-SpeedTest.ps1
+++ b/PSSpeedTest/public/Invoke-SpeedTest.ps1
@@ -49,7 +49,7 @@
 #>
 
 function Invoke-SpeedTest {
-    [CmdletBinding(SupportsShouldProcess=$True)]
+    [CmdletBinding()]
     Param (
         [Parameter(ParameterSetName="Internet")]
         [Switch]

--- a/PSSpeedTest/public/Invoke-SpeedTest.ps1
+++ b/PSSpeedTest/public/Invoke-SpeedTest.ps1
@@ -49,7 +49,7 @@
 #>
 
 function Invoke-SpeedTest {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess=$True)]
     Param (
         [Parameter(ParameterSetName="Internet")]
         [Switch]

--- a/PSSpeedTest/public/Invoke-SpeedTest.ps1
+++ b/PSSpeedTest/public/Invoke-SpeedTest.ps1
@@ -23,9 +23,6 @@
     
     .PARAMETER PassThru
     Returns a PSCustomObject with the send/receive speeds as properties.
-    
-    .PARAMETER Force
-    Skips any confirmations of installation of the ChocolateyGet PackageProvider and iPerf3 package.
 
     .EXAMPLE
     Invoke-SpeedTest -Internet
@@ -70,15 +67,13 @@ function Invoke-SpeedTest {
         [String]
         $Port,
         [Switch]
-        $PassThru,
-        [Switch]
-        $Force
+        $PassThru
     )
 
     Write-Verbose -Message "Starting speed test."
 
-    Install-ChocolateyGetProvider -Force:$Force
-    Install-iPerf3 -Force:$Force
+    Install-ChocolateyGetProvider
+    Install-iPerf3
 
     $config = Get-SpeedTestConfig -PassThru
     $command = "iperf3.exe "

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Whenever I've needed to run a network bandwidth test, I've defaulted to services
 
 `Install-Module -Name PSSpeedTest -Repository PSGallery`
 
-**NOTE:** Installing this module will not automatically install `ChocolateyGet` or `iPerf3`. Running `Invoke-SpeedTest` or `Install-SpeedTestServer` will prompt for the installation of these two items **if** they are not installed **or** the `-Force` argument is not given.
+**NOTE:** Installing this module will not automatically install `ChocolateyGet` or `iPerf3`. Running `Invoke-SpeedTest` or `Install-SpeedTestServer` will prompt for the installation of these two items **if** they are not installed **and** the global `$ConfirmationPreference` is not `'None'`.
 
 ## Usage (Public Functions)
 

--- a/tests/Feature.Tests.ps1
+++ b/tests/Feature.Tests.ps1
@@ -1,6 +1,7 @@
 $Script:ModuleRoot = Resolve-Path "$PSScriptRoot\..\output\$Env:BHProjectName"
 $Script:ModuleName = Split-Path $Script:ModuleRoot -Leaf
 $Script:ConfigPath = Join-Path -Path $Script:ModuleRoot -ChildPath "config.json"
+$Script:origConfirmPref = $ConfirmPreference
 
 function Reset-Configuration {
     $config = Get-Content -Path $Script:ConfigPath | ConvertFrom-Json
@@ -16,6 +17,11 @@ Describe "Feature tests for module $Script:ModuleName" {
         BeforeAll {
             Get-Module -All -Name $Script:ModuleName | Remove-Module -Force -ErrorAction 'Ignore'
             Import-Module $Global:TestThisModule
+            $ConfirmPreference = 'None'
+        }
+
+        AfterAll {
+            $ConfirmPreference = $Script:origConfirmPref
         }
         
         AfterEach {

--- a/tests/Feature.Tests.ps1
+++ b/tests/Feature.Tests.ps1
@@ -1,7 +1,7 @@
 $Script:ModuleRoot = Resolve-Path "$PSScriptRoot\..\output\$Env:BHProjectName"
 $Script:ModuleName = Split-Path $Script:ModuleRoot -Leaf
 $Script:ConfigPath = Join-Path -Path $Script:ModuleRoot -ChildPath "config.json"
-$Script:origConfirmPref = $ConfirmPreference
+$Global:origConfirmPref = $Global:ConfirmPreference
 
 function Reset-Configuration {
     $config = Get-Content -Path $Script:ConfigPath | ConvertFrom-Json
@@ -17,11 +17,11 @@ Describe "Feature tests for module $Script:ModuleName" {
         BeforeAll {
             Get-Module -All -Name $Script:ModuleName | Remove-Module -Force -ErrorAction 'Ignore'
             Import-Module $Global:TestThisModule
-            $ConfirmPreference = 'None'
+            $Global:ConfirmPreference = 'None'
         }
 
         AfterAll {
-            $ConfirmPreference = $Script:origConfirmPref
+            $Global:ConfirmPreference = $Global:origConfirmPref
         }
         
         AfterEach {

--- a/tests/Feature.Tests.ps1
+++ b/tests/Feature.Tests.ps1
@@ -24,38 +24,38 @@ Describe "Feature tests for module $Script:ModuleName" {
 
         It "Should successfully run a speed test against a valid public iPerf3 server with a saved configuration" {
             Set-SpeedTestConfig -InternetServer "iperf.he.net" -InternetPort "5201"
-            {Invoke-SpeedTest -Internet -PassThru -Force} | Should -Not -Throw
+            {Invoke-SpeedTest -Internet -PassThru} | Should -Not -Throw
         }
 
         It "Should successfully run a speed test against a valid public iPerf3 server with a saved configuration using default port '5201'" {
             Set-SpeedTestConfig -InternetServer "iperf.he.net"
-            {Invoke-SpeedTest -Internet -PassThru -Force} | Should -Not -Throw
+            {Invoke-SpeedTest -Internet -PassThru} | Should -Not -Throw
         }
 
         It "Should successfully run a speed test against a valid public iPerf3 server using specified Server/Port parameters" {
-            {Invoke-SpeedTest -Server "iperf.he.net" -Port "5201" -PassThru -Force} | Should -Not -Throw
+            {Invoke-SpeedTest -Server "iperf.he.net" -Port "5201" -PassThru} | Should -Not -Throw
         }
         
         It "Should successfully run a speed test against a valid public iPerf3 server using specified Server parameter and default port '5201'" {
-            {Invoke-SpeedTest -Server "iperf.he.net" -PassThru -Force} | Should -Not -Throw
+            {Invoke-SpeedTest -Server "iperf.he.net" -PassThru} | Should -Not -Throw
         }
 
         It "Should throw an error when running a speed test against an invalid public iPerf3 server with a saved configuration" {
             Set-SpeedTestConfig -InternetServer "test.local.com"
-            {Invoke-SpeedTest -Internet -PassThru -Force} | Should -Throw
+            {Invoke-SpeedTest -Internet -PassThru} | Should -Throw
         }
 
         It "Should throw an error when running a speed test against a valid public iPerf3 server with a saved configuration using an invalid port" {
             Set-SpeedTestConfig -InternetServer "test.local.com" -InternetPort "7777"
-            {Invoke-SpeedTest -Internet -PassThru -Force} | Should -Throw
+            {Invoke-SpeedTest -Internet -PassThru} | Should -Throw
         }
 
         It "Should throw an error when running a speed test against an invalid public iPerf3 server/port using specified Server/Port parameters" {
-            {Invoke-SpeedTest -Server "test.local.com" -Port "7777" -PassThru -Force} | Should -Throw
+            {Invoke-SpeedTest -Server "test.local.com" -Port "7777" -PassThru} | Should -Throw
         }
 
         It "Should throw an error when running a speed test against an invalid public iPerf3 server using specified Server parameter" {
-            {Invoke-SpeedTest -Server "test.local.com" -PassThru -Force} | Should -Throw
+            {Invoke-SpeedTest -Server "test.local.com" -PassThru} | Should -Throw
         }
     }
 
@@ -66,7 +66,7 @@ Describe "Feature tests for module $Script:ModuleName" {
         }
 
         It "Should install iPerf3 scheduled task listener on local computer" {
-            {Install-SpeedTestServer -Force} | Should -Not -Throw
+            {Install-SpeedTestServer} | Should -Not -Throw
         }
     }
 }

--- a/tests/PrivateFunctions.Tests.ps1
+++ b/tests/PrivateFunctions.Tests.ps1
@@ -1,7 +1,7 @@
 $Script:ModuleRoot = Resolve-Path "$PSScriptRoot\..\output\$Env:BHProjectName"
 $Script:ModuleName = Split-Path $Script:ModuleRoot -Leaf
 $Script:PrivateFunctionPath = "$Script:ModuleRoot\private"
-$Script:origConfirmPref = $ConfirmPreference
+$Global:origConfirmPref = $Global:ConfirmPreference
 
 foreach ($script in (Get-ChildItem -Path $Script:PrivateFunctionPath)) {
     . $script.FullName
@@ -9,11 +9,11 @@ foreach ($script in (Get-ChildItem -Path $Script:PrivateFunctionPath)) {
 
 Describe "Private function tests for $Script:ModuleName" {
     BeforeAll {
-        $ConfirmPreference = 'None'
+        $Global:ConfirmPreference = 'None'
     }
 
     AfterAll {
-        $ConfirmPreference = $Script:origConfirmPref
+        $Global:ConfirmPreference = $Global:origConfirmPref
     }
 
     Context "Install-ChocolateyGetProvider" {

--- a/tests/PrivateFunctions.Tests.ps1
+++ b/tests/PrivateFunctions.Tests.ps1
@@ -1,12 +1,20 @@
 $Script:ModuleRoot = Resolve-Path "$PSScriptRoot\..\output\$Env:BHProjectName"
 $Script:ModuleName = Split-Path $Script:ModuleRoot -Leaf
 $Script:PrivateFunctionPath = "$Script:ModuleRoot\private"
+$Script:origConfirmPref = $ConfirmPreference
 
 foreach ($script in (Get-ChildItem -Path $Script:PrivateFunctionPath)) {
     . $script.FullName
 }
 
 Describe "Private function tests for $Script:ModuleName" {
+    BeforeAll {
+        $ConfirmPreference = 'None'
+    }
+
+    AfterAll {
+        $ConfirmPreference = $Script:origConfirmPref
+    }
 
     Context "Install-ChocolateyGetProvider" {
         It "Should install ChocolateyGet PackageProvider" {

--- a/tests/PrivateFunctions.Tests.ps1
+++ b/tests/PrivateFunctions.Tests.ps1
@@ -10,13 +10,13 @@ Describe "Private function tests for $Script:ModuleName" {
 
     Context "Install-ChocolateyGetProvider" {
         It "Should install ChocolateyGet PackageProvider" {
-            {Install-ChocolateyGetProvider -Force} | Should -Not -Throw
+            {Install-ChocolateyGetProvider} | Should -Not -Throw
         }
     }
 
     Context "Install-iPerf3" {
         It "Should install iPerf3 Package from ChocolateyGet" {
-            {Install-iPerf3 -Force} | Should -Not -Throw
+            {Install-iPerf3} | Should -Not -Throw
         }
     }
 


### PR DESCRIPTION
`Install-ChocolateyGetProvider` and `Install-iPerf3` will prompt by default unless disabled by the user.

This fixes #32.